### PR TITLE
docs(agents): add root AGENTS.md as memory and CLAUDE.md pointer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,15 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+> **Toda la documentación y la memoria del proyecto viven en [backend/AGENTS.md](./backend/AGENTS.md).**
+>
+> El foco actual del trabajo es el **backend** (Rust 2024, gRPC con `tonic`/`axum`,
+> Arquitectura Cebolla y Bounded Context Crates alineados con HL7 FHIR R4).
+> Allí están los comandos de build/test, las capas y sus límites, la inyección de
+> dependencias, las convenciones de código, la guía de testing y las reglas de
+> commits/PR. Cada contexto acotado tiene además su propia guía en
+> `backend/crates/<dominio>/AGENTS.md`.
+>
+> Consulta y mantén **AGENTS.md** como la única fuente de verdad: este archivo es
+> solo un puntero y no debe acumular contenido propio.

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -197,17 +197,17 @@ Para consultar la especificación detallada del modelo de dominio de cada contex
 
 | Bounded Context | Crate | Recurso FHIR Mapeado | Documentación dedicada |
 | :--- | :--- | :--- | :--- |
-| **Casos de Uso e Identidad** | N/A | Flujos de Identidad y Registro | [docs/use_cases.md](file:///home/miuler/proyectos/my-health-record/backend/docs/use_cases.md) |
-| **Identity & Security** | `crates/user` | `Person` + `User` | [crates/user/AGENTS.md](file:///home/miuler/proyectos/my-health-record/backend/crates/user/AGENTS.md) |
-| **Gestión Administrativa** | `crates/administration` | `Patient`, `Practitioner`, `Location`, `HealthcareService` | [crates/administration/AGENTS.md](file:///home/miuler/proyectos/my-health-record/backend/crates/administration/AGENTS.md) |
-| **Reserva de Citas** | `crates/scheduling` | `Schedule`, `Slot`, `Appointment` | [crates/scheduling/AGENTS.md](file:///home/miuler/proyectos/my-health-record/backend/crates/scheduling/AGENTS.md) |
-| **Historia Clínica** | `crates/clinical` | `Encounter`, `Condition`, `AllergyIntolerance`, `CarePlan`, `MedicationRequest`, `Questionnaire` | [crates/clinical/AGENTS.md](file:///home/miuler/proyectos/my-health-record/backend/crates/clinical/AGENTS.md) |
-| **Laboratorio e Imágenes** | `crates/diagnostics` | `ServiceRequest`, `Observation`, `DiagnosticReport`, `ImagingStudy`, `Specimen` | [crates/diagnostics/AGENTS.md](file:///home/miuler/proyectos/my-health-record/backend/crates/diagnostics/AGENTS.md) |
-| **Farmacia e Insumos** | `crates/pharmacy` | `Medication`, `MedicationDispense`, `MedicationAdministration`, `SupplyRequest` / `SupplyDelivery` | [crates/pharmacy/AGENTS.md](file:///home/miuler/proyectos/my-health-record/backend/crates/pharmacy/AGENTS.md) |
-| **Aseguradoras y Coberturas** | `crates/coverage` | `Coverage`, `Claim`, `ClaimResponse`, `CoverageEligibilityRequest` | [crates/coverage/AGENTS.md](file:///home/miuler/proyectos/my-health-record/backend/crates/coverage/AGENTS.md) |
-| **Facturación** | `crates/billing` | `Account`, `Invoice`, `ChargeItem` | [crates/billing/AGENTS.md](file:///home/miuler/proyectos/my-health-record/backend/crates/billing/AGENTS.md) |
-| **Archivo Legal y Auditoría** | `crates/legal_archive` | `Composition`, `DocumentReference`, `AuditEvent`, `Provenance` | [crates/legal_archive/AGENTS.md](file:///home/miuler/proyectos/my-health-record/backend/crates/legal_archive/AGENTS.md) |
-| **Notificaciones y Alertas** | `crates/communication` | `Communication`, `CommunicationRequest`, `Flag` | [crates/communication/AGENTS.md](file:///home/miuler/proyectos/my-health-record/backend/crates/communication/AGENTS.md) |
+| **Casos de Uso e Identidad** | N/A | Flujos de Identidad y Registro | [docs/use_cases.md](docs/use_cases.md) |
+| **Identity & Security** | `crates/user` | `Person` + `User` | [crates/user/AGENTS.md](crates/user/AGENTS.md) |
+| **Gestión Administrativa** | `crates/administration` | `Patient`, `Practitioner`, `Location`, `HealthcareService` | [crates/administration/AGENTS.md](crates/administration/AGENTS.md) |
+| **Reserva de Citas** | `crates/scheduling` | `Schedule`, `Slot`, `Appointment` | [crates/scheduling/AGENTS.md](crates/scheduling/AGENTS.md) |
+| **Historia Clínica** | `crates/clinical` | `Encounter`, `Condition`, `AllergyIntolerance`, `CarePlan`, `MedicationRequest`, `Questionnaire` | [crates/clinical/AGENTS.md](crates/clinical/AGENTS.md) |
+| **Laboratorio e Imágenes** | `crates/diagnostics` | `ServiceRequest`, `Observation`, `DiagnosticReport`, `ImagingStudy`, `Specimen` | [crates/diagnostics/AGENTS.md](crates/diagnostics/AGENTS.md) |
+| **Farmacia e Insumos** | `crates/pharmacy` | `Medication`, `MedicationDispense`, `MedicationAdministration`, `SupplyRequest` / `SupplyDelivery` | [crates/pharmacy/AGENTS.md](crates/pharmacy/AGENTS.md) |
+| **Aseguradoras y Coberturas** | `crates/coverage` | `Coverage`, `Claim`, `ClaimResponse`, `CoverageEligibilityRequest` | [crates/coverage/AGENTS.md](crates/coverage/AGENTS.md) |
+| **Facturación** | `crates/billing` | `Account`, `Invoice`, `ChargeItem` | [crates/billing/AGENTS.md](crates/billing/AGENTS.md) |
+| **Archivo Legal y Auditoría** | `crates/legal_archive` | `Composition`, `DocumentReference`, `AuditEvent`, `Provenance` | [crates/legal_archive/AGENTS.md](crates/legal_archive/AGENTS.md) |
+| **Notificaciones y Alertas** | `crates/communication` | `Communication`, `CommunicationRequest`, `Flag` | [crates/communication/AGENTS.md](crates/communication/AGENTS.md) |
 
 ---
 


### PR DESCRIPTION
Las sesiones de agentes arrancan en la raíz del monorepo, donde no existía
ningún AGENTS.md ni CLAUDE.md, por lo que no se cargaba automáticamente
ninguna guía: toda la documentación vivía bajo backend/.

- AGENTS.md (raíz): punto de entrada y memoria persistente del monorepo.
  Define la política de memoria (AGENTS.md como única fuente de verdad, sin
  MEMORY.md, CLAUDE.md solo como puntero, ámbito más específico gana), el
  mapa de backend/frontend/frontendts/proto, las reglas transversales y los
  comandos de cargo-make.
- CLAUDE.md (raíz): puntero a AGENTS.md, sin contenido duplicado, siguiendo
  el mismo patrón ya usado por backend/CLAUDE.md.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XDkWdE28hUWJ4Z4cAX7yMm